### PR TITLE
Scopus bez vysledkov

### DIFF
--- a/scopus.py
+++ b/scopus.py
@@ -160,8 +160,12 @@ class ScopusWebConnection(DataSourceConnection):
     
     et = html5lib.parse(export_form_response.text, treebuilder="lxml")
     export_form = et.find("//{http://www.w3.org/1999/xhtml}form[@name='exportForm']")
+
+    if export_form is None:
+        return []
+
     form = HTMLForm(export_form)
-    
+
    #form.set_value('exportFormat', 'CSV')
    #form.set_value('view', 'SpecifyFields')
    #form.check('selectedOtherInformationItems', ['Conference information'])


### PR DESCRIPTION
Ak pride k vynimke pri HTMLForm (form nema action), znamena to, ze ziadne vysledky neboli najdene.

Vratena vynimka vyzerala nejako takto:

```
    File "citacie/htmlform.py", line 23, in __init__
            self.action = form_et.attrib.get('action', None)
    AttributeError: 'NoneType' object has no attribute 'attrib'
```
