### PR TITLE
Scopus feff fix

### DIFF
--- a/scopus.py
+++ b/scopus.py
@@ -219,6 +219,12 @@ class ScopusWebConnection(DataSourceConnection):
       return int(x)
     
     for line in csv:
+      # (mrshu): scopus teraz pridava na zaciatok CSV suborov U+FEFF, u nas sa
+      # to prejavi tak, ze Authors to maju pred sebou. Toto je dost smutny
+      # zhackovany fix, ktory by mal aspon fungovat
+
+      line['Authors'] = line[u'\ufeffAuthors']
+
       if line['Authors'] == '[No author name available]':
         authors = []
       else:


### PR DESCRIPTION
Scopus sa rozhodol, ze bude vracat U+FEFF na zaciatku kazdeho CSV, nam
sa to prejavi tak, ze namiesto 'Authors' mame potom '\ufeffAuthors'. Preco
sa to rozhodol spravit (a preco prave teraz) je otazne, kazdopadne som
sa pokusil to rychlo vyriesit takymto malym zhackovanym fixom.
