### PR TITLE
wok: Fixnuty problem s WOK

### DIFF
--- a/wok.py
+++ b/wok.py
@@ -584,9 +584,9 @@ class WokWebConnection(DataSourceConnection):
       with self.throttler():
         r2 = self.session.post('http://apps.webofknowledge.com/OutboundService.do?action=go&&', data=data, headers=headers)
       
-      self._log_tab_delimited(cite_url, origin_ut, r2.text)
+      self._log_tab_delimited(cite_url, origin_ut, r2.content)
       
-      for pub in self._parse_tab_delimited(r2.text):
+      for pub in self._parse_tab_delimited(r2.content):
         yield pub
   
   def _parse_tab_delimited(self, text):


### PR DESCRIPTION
* WOK z nejakeho dovodu vracal namiesto citacii cinsky text z naozaj
  neznamych dovodov. Po urputnom boji sa ukazalo, ze pouzitie `.content`
  namiesto `.text` tento problem vyriesilo. Otazkou zostava, ako je
  mozne, ze to fungovalo predtym.

Signed-off-by: mr.Shu <mr@shu.io>