### PR TITLE
wok: Lepsi fix pre encoding problem

### DIFF
--- a/wok.py
+++ b/wok.py
@@ -584,9 +584,10 @@ class WokWebConnection(DataSourceConnection):
       with self.throttler():
         r2 = self.session.post('http://apps.webofknowledge.com/OutboundService.do?action=go&&', data=data, headers=headers)
       
-      self._log_tab_delimited(cite_url, origin_ut, r2.content)
+      r2.encoding = 'UTF-8'
+      self._log_tab_delimited(cite_url, origin_ut, r2.text)
       
-      for pub in self._parse_tab_delimited(r2.content):
+      for pub in self._parse_tab_delimited(r2.text):
         yield pub
   
   def _parse_tab_delimited(self, text):


### PR DESCRIPTION
* Ukazalo sa, ze WoK prestal dobre nastavovat kodovanie v hlavicke a
  requests nejakym sposobom vyinferovalo, ze to bude UTF-16LE -- odtial
  aj cinske znaky.

  Tento commit nastavi r2.encoding natvrdo na 'UTF-8' a namiesto
  `.content` pouziva `.text`, ktory text vracia v unicode, co sa neskor
  v kode ocakava.

Signed-off-by: mr.Shu <mr@shu.io>

------------------------------------

Pokracovanie #10, v zasade sa toto ukazuje byt lepsie riesenie.