### PR TITLE
scopusapi: Hotfix pre pagination

### DIFF
--- a/scopusapi.py
+++ b/scopusapi.py
@@ -54,6 +54,10 @@ class ScopusAPIConnection(DataSourceConnection):
             next_link = self.find_next_url(raw_json['search-results']['link'])
             if next_link is None:
                 break
+            # (mrshu): hotfix pre scopus, z nejakeho dovodu ocakavaju, ze HTTPS
+            # pojde aj na porte 80
+            next_link = next_link.replace('api.elsevier.com:80',
+                                          'api.elsevier.com:443')
             raw_json = requests.get(next_link).json()
             entries = raw_json['search-results']['entry']
             for pub in self.entries_to_publications(entries):


### PR DESCRIPTION
- SCOPUS vo fielde next_link (kde by mal byt odkaz na stranku s dalsimi
  vysledkami vyhladavania) explicitne uvadza https://api.scopus.com:80
  
  To nerobi dobrotu. Tento commmit to hotfixuje zmenenim 80 na 443.

Signed-off-by: mr.Shu mr@shu.io
